### PR TITLE
Add Weather Underground relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ No PHP or web server needed&mdash;just Python and Flask!
 - Pushes sensor data to Home Assistant as custom sensors via its REST API
 - Dockerized for simple deployment anywhere
 - Responds with `success` so the weather station doesn’t retry
+- Optional relay of data to Weather Underground using Google DNS
 
 ---
 
@@ -31,6 +32,9 @@ Edit the `docker-compose.yml` file and set the following variables:
 
 - `HA_URL`: Base URL to your Home Assistant API (e.g., `http://192.168.1.100:8123/api/states/`)
 - `HA_TOKEN`: Your Home Assistant long-lived access token
+- `WU_RELAY`: Set to `true` to also forward data to Weather Underground
+- `WU_ID`: (Optional) Weather Underground station ID used when relaying
+- `WU_PASSWORD`: (Optional) Weather Underground password/key for relaying
 
 Example:
 
@@ -39,6 +43,9 @@ environment:
   TZ: Europe/Berlin
   HA_URL: http://192.168.1.100:8123/api/states/
   HA_TOKEN: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  WU_RELAY: "true"
+  WU_ID: YOUR_WU_ID
+  WU_PASSWORD: YOUR_WU_PASSWORD
 ```
 
 ### 3. Build and run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,6 @@ services:
       TZ: Europe/Berlin
       HA_URL: http://xx.xx.xx.xx:8123/api/states/      # <-- SET YOUR HA URL
       HA_TOKEN: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx # <-- SET YOUR TOKEN
+      WU_RELAY: "false"                               # Relay to Weather Underground
+      WU_ID: ""                                       # Optional WU station ID
+      WU_PASSWORD: ""                                 # Optional WU station key

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 requests
 pytz
+dnspython


### PR DESCRIPTION
## Summary
- support optional forwarding to Weather Underground via Google DNS
- add env vars `WU_RELAY`, `WU_ID`, `WU_PASSWORD`
- update example configuration and docs
- include `dnspython` in requirements

## Testing
- `python -m py_compile weatherstation.py`

------
https://chatgpt.com/codex/tasks/task_e_6846bcf912c8832ca37d7f8b0d1a6fb5