### PR TITLE
Add DNS rebind warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Example DNS override:
 ```
 rtupdate.wunderground.com    <your-server-ip>
 ```
+**Note:** If your router has DNS rebind protection enabled, you must allow this domain in your router settings when overriding DNS with Pi-hole.
 
 On the weather station, enable Weather Underground uploads with any station ID/key.
 


### PR DESCRIPTION
## Summary
- add note about DNS rebind protection in Station Configuration section of README

## Testing
- `python -m py_compile weatherstation.py`


------
https://chatgpt.com/codex/tasks/task_e_6846bd6d757c832cbc613d0768ab21c1