### PR TITLE
Add forwarding to Weather Underground

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Edit the `docker-compose.yml` file and set the following variables:
 - `DEVICE_MANUFACTURER`: (optional) Manufacturer name shown in Home Assistant (default `VEVOR`)
 - `DEVICE_MODEL`: (optional) Model name (default `7-in-1 Weather Station`)
 - `UNITS`: `metric` (default) or `imperial`
+- `WU_FORWARD`: Set to `true` to also forward data to Weather Underground (default `false`)
+- `WU_USERNAME` / `WU_PASSWORD`: Credentials for Weather Underground (optional)
 
 Example:
 
@@ -52,6 +54,11 @@ environment:
   DEVICE_MODEL: "7-in-1 Weather Station"
   # optional: "metric" (default) or "imperial"
   UNITS: metric
+  # forward data to Weather Underground
+  WU_FORWARD: "false"
+  # credentials if forwarding
+  WU_USERNAME: yourWUuser
+  WU_PASSWORD: yourWUpass
 ```
 
 ### 3. Build and run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,3 +17,8 @@ services:
       DEVICE_MODEL: "7-in-1 Weather Station"  # <-- Optional model name
       # UNITS can be "metric" or "imperial". Default is metric
       UNITS: metric
+      # forward data to Weather Underground
+      WU_FORWARD: "false"
+      # credentials for Weather Underground (optional)
+      WU_USERNAME: wu-user
+      WU_PASSWORD: wu-pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 Flask
 pytz
 paho-mqtt
+requests
+dnspython


### PR DESCRIPTION
## Summary
- add `requests` and `dnspython` dependencies
- add optional Weather Underground forwarding in `weatherstation.py`
- document new environment variables and compose example
- expose forwarding options in `docker-compose.yml`

## Testing
- `python -m py_compile weatherstation.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_684956e10f90832cb9b076c02a9d77ae